### PR TITLE
Adapt bloom only

### DIFF
--- a/Shaders/qUINT_bloom.fx
+++ b/Shaders/qUINT_bloom.fx
@@ -335,9 +335,9 @@ void PS_Combine(in float4 pos : SV_Position, in float2 uv : TEXCOORD, out float4
 	
 	float adapt = tex2D(sMXBLOOM_BloomTexAdapt, 0).x + 1e-3; // we lerped to 0.5 earlier.
 	adapt *= 8;
+	bloom.rgb *= lerp(1, rcp(adapt), BLOOM_ADAPT_STRENGTH);
 
 	color.rgb += bloom.rgb;
-	color.rgb *= lerp(1, rcp(adapt), BLOOM_ADAPT_STRENGTH); 
 	color.rgb *= exp2(BLOOM_ADAPT_EXPOSURE);
 
 	color.rgb = pow(max(0,color.rgb), BLOOM_TONEMAP_COMPRESSION);


### PR DESCRIPTION
Adapting only the bloom gives a more natural look than adapting the entire image, which can mess up colors badly in some scenes.

### Example from a very dark scene in Dead Space:
Both adaptation images have the exact same settings for bloom, so they don't really matter, but just for reference: they're using 0.5 Adaptation Sensitivity(0 on the "No Adaptation" image). The only difference is that 1 line of code in the shader.
## No Adaptation
![NoAdaptation](https://user-images.githubusercontent.com/24507868/122263907-3bb5e900-ced7-11eb-93cb-cfd4d1a1853e.png)
## Adapt Bloom Only(suggested change)
![AdaptBloomOnly](https://user-images.githubusercontent.com/24507868/122263969-4f614f80-ced7-11eb-93c2-01e869ef1f4b.png)
## Adapt Entire Image(**current functionality**)
![AdaptEntireImage](https://user-images.githubusercontent.com/24507868/122264006-59834e00-ced7-11eb-818c-eb0e38aeed55.png)
