### PR TITLE
Enabled Lens dirt option

### DIFF
--- a/Shaders/qUINT_bloom.fx
+++ b/Shaders/qUINT_bloom.fx
@@ -47,14 +47,14 @@ uniform float BLOOM_SAT <
 	ui_label = "Bloom Saturation";
 	ui_tooltip = "Adjusts the color strength of the bloom effect";
 > = 2.0;
-/*
+
 uniform float BLOOM_DIRT <
 	ui_type = "drag";
 	ui_min = 0.00; ui_max = 2.00;
 	ui_label = "Lens Dirt Amount";
 	ui_tooltip = "Applies a dirt mask on top of the original bloom.";
 > = 0.0;
-*/
+
 uniform float BLOOM_LAYER_MULT_1 <
 	ui_type = "drag";
 	ui_min = 0.00; ui_max = 1.00;


### PR DESCRIPTION
**Was surprised to found a whole code for the lens dirt option just laying in the fx file disabled. Works as it should except the fact that there is absolutely no mask.**

Would have tried to code some dirt textures into it but not that experienced. Hope you can update the option for full functionality, though! Dirt is really a nice effect.

And i can just try ambient lighting but its kinda performance heavy.

![pic](https://user-images.githubusercontent.com/88745789/129118884-b12341a0-2360-46e0-813d-8d2c77e5fdb6.png)

